### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **React + TypeScript portfolio SPA** built with Vite 5 and MUI v6. There is no backend, database, or external API — the contact form uses a `mailto:` link.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `yarn install` |
+| Dev server | `yarn dev` (Vite on port 5173) |
+| Lint | `yarn lint` (ESLint 9) |
+| Build | `yarn build` (`tsc -b && vite build`) |
+| Preview prod build | `yarn preview` |
+
+### Notes
+
+- **Package manager**: Yarn v1 classic (`yarn.lock` present). Do not use npm.
+- **Styling**: SCSS + MUI theme. The Vite config silences the `legacy-js-api` Sass deprecation warning — this is intentional.
+- **No test framework**: The project does not have a test runner configured (no Jest/Vitest). If tests are needed, add Vitest.
+- **Node version**: Node.js 20 LTS is required (installed via NodeSource).
+- **Dev server host**: Use `yarn dev --host 0.0.0.0` to make the dev server accessible outside localhost in the Cloud VM.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents, and fixes `.gitignore` to exclude TypeScript build artifacts.

### What's included

- `AGENTS.md`: Key commands table (install, dev, lint, build, preview), package manager guidance (Yarn v1), styling/Sass notes, Node.js version requirement, dev server host flag for Cloud VM
- `.gitignore`: Added `*.tsbuildinfo` to prevent committing TypeScript incremental build artifacts

### Demo

[portfolio_site_demo.mp4](https://cursor.com/agents/bc-26eeab07-7ae3-4c46-b087-065bb3dc4e58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_demo.mp4)

Portfolio site running on Vite dev server with working navigation and smooth scrolling.

[Homepage hero section](https://cursor.com/agents/bc-26eeab07-7ae3-4c46-b087-065bb3dc4e58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)
[Projects section](https://cursor.com/agents/bc-26eeab07-7ae3-4c46-b087-065bb3dc4e58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprojects_section.webp)
[Contact section](https://cursor.com/agents/bc-26eeab07-7ae3-4c46-b087-065bb3dc4e58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_section.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26eeab07-7ae3-4c46-b087-065bb3dc4e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26eeab07-7ae3-4c46-b087-065bb3dc4e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

